### PR TITLE
feature/add_imagemagick

### DIFF
--- a/templates/auto_package.rb
+++ b/templates/auto_package.rb
@@ -16,4 +16,8 @@ Bankai::Docker.setup do
   detect_package :sassc, :gem do |package|
     package.add_runtime_dependency 'libstdc++' if gem?('sassc')
   end
+
+  detect_package :mini_magick, :gem do |package|
+    package.add_runtime_dependency 'imagemagick' if gem?('mini_magick')
+  end
 end


### PR DESCRIPTION
有安裝 `gem mini_magick` 就安裝 `imagemagick`

已在本地端測試過產生的 container 可以有 `mini_magick` 的裁切圖片的效果